### PR TITLE
Fix connection issues to a Voltage Node

### DIFF
--- a/backend-lightning-mediastore/index.js
+++ b/backend-lightning-mediastore/index.js
@@ -33,9 +33,7 @@ let macaroonCreds = grpc.credentials.createFromMetadataGenerator((_args, callbac
   callback(null, metadata);
 });
 
-let lndCert = fs.readFileSync(process.env.PATH_TO_TLS_CERT);
-
-let sslCreds = grpc.credentials.createSsl(lndCert);
+let sslCreds = grpc.credentials.createSsl();
 let credentials = grpc.credentials.combineChannelCredentials(sslCreds, macaroonCreds);
 
 let lnrpcDescriptor = grpc.loadPackageDefinition(packageDefinition);


### PR DESCRIPTION
This will fix connection issues to a Voltage node. Voltage uses CA signed TLS certificates so there's no need to manually specify them in the config. 